### PR TITLE
Feature/매핑 시 오류 수정 및 SearchDto 필드 추가

### DIFF
--- a/src/main/java/kitri/dev6/memore/domain/Article.java
+++ b/src/main/java/kitri/dev6/memore/domain/Article.java
@@ -1,5 +1,6 @@
 package kitri.dev6.memore.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -17,10 +18,12 @@ public class Article {
     private String title;
     private String content;
     private int viewCount;
+    @JsonProperty("isDone")
     private boolean isDone;
     private LocalDate startDate;
     private LocalDate endDate;
     private int ratingScore;
+    @JsonProperty("isHide")
     private boolean isHide;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;

--- a/src/main/java/kitri/dev6/memore/dto/common/SearchDto.java
+++ b/src/main/java/kitri/dev6/memore/dto/common/SearchDto.java
@@ -33,6 +33,8 @@ public class SearchDto {
     private String sortAs;          // 정렬 순서
     private String searchKeyword;       // 검색 키워드
     private String searchType;    // 검색 유형 (제목, 아이디, 날짜...)
+    private String searchKeyword2;       // 검색 키워드
+    private String searchType2;    // 검색 유형 (제목, 아이디, 날짜...)
     private Pagination pagination; // 페이지네이션 정보
     private String joinWith;
     private String apiFrom;

--- a/src/main/java/kitri/dev6/memore/dto/request/ArticleRequestDto.java
+++ b/src/main/java/kitri/dev6/memore/dto/request/ArticleRequestDto.java
@@ -1,5 +1,6 @@
 package kitri.dev6.memore.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import kitri.dev6.memore.domain.Article;
 import lombok.*;
 
@@ -19,13 +20,13 @@ public class ArticleRequestDto {
     @NotEmpty
     private String title;
     private String content;
-    @NotEmpty
+    @NotEmpty @JsonProperty("isDone")
     private boolean isDone;
     @NotEmpty
     private LocalDate startDate;
     private LocalDate endDate;
     private int ratingScore;
-    @NotEmpty
+    @NotEmpty @JsonProperty("isHide")
     private boolean isHide;
 
     public Article toDomain(){

--- a/src/main/java/kitri/dev6/memore/repository/sql/QueryUtils.java
+++ b/src/main/java/kitri/dev6/memore/repository/sql/QueryUtils.java
@@ -8,7 +8,7 @@ public class QueryUtils {
     static HashSet<String> likeCompareSet =
             new HashSet<>(List.of(new String[]{"title", "content"}));
     static HashSet<String> exactCompareSet =
-            new HashSet<>(List.of(new String[]{"id", "member_id", "book_id", "category_id", "view_count", "rating_score"}));
+            new HashSet<>(List.of(new String[]{"id", "member_id", "book_id", "category_id", "view_count", "rating_score", "is_done", "is_hide"}));
     static HashSet<String> exactCompareWithQuotesSet =
             new HashSet<>(List.of(new String[]{"name", "c.name", "email", "m.name" }));
 

--- a/src/main/java/kitri/dev6/memore/repository/sql/Sql.java
+++ b/src/main/java/kitri/dev6/memore/repository/sql/Sql.java
@@ -56,6 +56,8 @@ public class Sql {
         if (!StringUtils.isEmpty(params.getSearchKeyword())) {
             if (!StringUtils.isEmpty(params.getSearchType())) {
                 query.WHERE(QueryUtils.procSearchInput(params.getSearchType(), params.getSearchKeyword()));
+                query.AND();
+                query.WHERE(QueryUtils.procSearchInput(params.getSearchType2(), params.getSearchKeyword2()));
             }
         }
         query.ORDER_BY(QueryUtils.sortAs(params.getSortType(), params.getSortAs()));


### PR DESCRIPTION
1. Boolean 타입의 경우 is로 시작하면 클라이언트에서 요청한 값을 읽지 못하는 오류가 발생합니다.
@JsonProperty("is~") 를 명시하여 문제를 해결할 수 있었습니다.

2. 다양한 조건 검색식을 대응하기 위해 SearchDto에 조건식 필드를 추가하였습니다.
- SearchType2, SearchKeyword2